### PR TITLE
🔧 fix: pass player id through in turn responses

### DIFF
--- a/server/game.js
+++ b/server/game.js
@@ -167,7 +167,7 @@ export const update = (uuidToUpdate, { cellToClaim, playerUuid }) => {
 		player.isWinner = true;
 	}
 
-	return { game: toPublicGame(game), isUpdated: true };
+	return { game: toPublicGame(game, { playerUuid }), isUpdated: true };
 };
 
 /**


### PR DESCRIPTION
Otherwise the player won’t know who they are in the response data