### PR TITLE
refactor: change id length for nicer urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,32 +60,32 @@ No request body is required or supported. The response body will be in JSON form
 		"isTheirTurn": true,
 		"isWinner": null,
 		"name": "Player O",
-		"uuid": "11111111-1111-1111-1111-111111111111"
+		"id": "11111"
 	}, {
 		"isTheirTurn": false,
 		"isWinner": null,
 		"name": "Player X",
-		"uuid": "22222222-2222-2222-2222-222222222222"
+		"id": "22222"
 	}],
-	"uuid": "00000000-0000-0000-0000-000000000000"
+	"id": "00000"
 }
 ```
 
-Make note of the players’ UUIDs from the POST response: you’ll need these to validate a turn later,
-because player UUIDs are omitted from any subsequent responses. This mechanism is intended to provide
-rudementary authentication of turns, while keeping the API simple. Think of a player UUID as an
+Make note of the players’ IDs from the POST response: you’ll need these to validate a turn later,
+because player IDs are omitted from any subsequent responses. This mechanism is intended to provide
+rudementary authentication of turns, while keeping the API simple. Think of a player ID as an
 API key for that player. The downside is that whoever creates the game must be trusted to know
-both players’ UUIDs!
+both players’ IDs!
 
-### `GET /api/games/:uuid`
+### `GET /api/games/:gameId`
 
-Send a GET request to `/api/games/:gameUuid` to receive the current state of your Tic-tac-toe game.
-Accepts an optional header, `Player-UUID`, if you want to include the UUID of a player in the
+Send a GET request to `/api/games/:gameId` to receive the current state of your Tic-tac-toe game.
+Accepts an optional header, `Player-ID`, if you want to include the ID of a player in the
 response. This header is useful for inferring the state of a player, for example: if you want to
 serve an HTML page to the player, in order to infer if it’s their turn in the game, you need to know
-which of the players in the players array is actually them. In other words, sending the `Player-UUID` header lets you identify a player within the response’s players array.
+which of the players in the players array is actually them. In other words, sending the `Player-ID` header lets you identify a player within the response’s players array.
 
-#### Example response of a request with no optional `Player-UUID` header
+#### Example response of a request with no optional `Player-ID` header
 
 `200 OK`
 
@@ -105,11 +105,11 @@ which of the players in the players array is actually them. In other words, send
 		"isWinner": null,
 		"name": "Player X"
 	}],
-	"uuid": "00000000-0000-0000-0000-000000000000"
+	"id": "00000"
 }
 ```
 
-#### Example response of a request with a `Player-UUID` header of `22222222-2222-2222-2222-222222222222`
+#### Example response of a request with a `Player-ID` header of `22222`
 
 `200 OK`
 
@@ -128,15 +128,15 @@ which of the players in the players array is actually them. In other words, send
 		"isTheirTurn": false,
 		"isWinner": null,
 		"name": "Player X",
-		"uuid": "22222222-2222-2222-2222-222222222222"
+		"id": "22222"
 	}],
-	"uuid": "00000000-0000-0000-0000-000000000000"
+	"id": "00000"
 }
 ```
 
-### `POST /api/games/:gameUuid/turn`
+### `POST /api/games/:gameId/turn`
 
-Calls to `/api/games/:gameUuid/turn` will change the state of the game board by taking the requested player’s turn in the game. Requests must include a `Content-Type` header with a value of `application/json`. If a successful response is returned, it will then be the other player’s turn.
+Calls to `/api/games/:gameId/turn` will change the state of the game board by taking the requested player’s turn in the game. Requests must include a `Content-Type` header with a value of `application/json`. If a successful response is returned, it will then be the other player’s turn.
 
 #### Example request
 
@@ -144,13 +144,13 @@ Calls to `/api/games/:gameUuid/turn` will change the state of the game board by 
 ```json
 {
 	"cellToClaim": 3,
-	"playerUuid": "11111111-1111-1111-1111-111111111111"
+	"playerId": "11111"
 }
 ```
 
 `cellToClaim` should be an integer from 0 through 8, where cells `0`, `1`, and `2` are the first row, `3`, `4`, and `5` are the second, and `6`, `7`, and `8` represent cells from the third row.
 
-`playerUuid` should be the UUID of the player taking a turn. Player UUIDs were given on creation of the game.
+`playerId` should be the ID of the player taking a turn. Player IDs were given on creation of the game.
 
 #### Example response
 
@@ -172,7 +172,7 @@ Calls to `/api/games/:gameUuid/turn` will change the state of the game board by 
 		"isWinner": null,
 		"name": "Player X"
 	}],
-	"uuid": "00000000-0000-0000-0000-000000000000"
+	"id": "00000"
 }
 ```
 

--- a/config.js
+++ b/config.js
@@ -1,6 +1,7 @@
 export default {
 	API_KEYS: process.env.API_KEYS,
 	APP_FRIENDLY_NAME: 'Tic-tac-toe API',
+	ID_LENGTH: Number(process.env.ID_LENGTH) || 5,
 	IS_PRODUCTION: process.env.NODE_ENV === 'production',
 	PORT: process.env.PORT || 3000
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.17.3",
-        "helmet": "^5.0.1"
+        "helmet": "^5.0.1",
+        "short-unique-id": "^4.4.4"
       },
       "devDependencies": {
         "@types/express": "^4.17.13",
@@ -5963,6 +5964,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/short-unique-id": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/short-unique-id/-/short-unique-id-4.4.4.tgz",
+      "integrity": "sha512-oLF1NCmtbiTWl2SqdXZQbo5KM1b7axdp0RgQLq8qCBBLoq+o3A5wmLrNM6bZIh54/a8BJ3l69kTXuxwZ+XCYuw==",
+      "bin": {
+        "short-unique-id": "bin/short-unique-id",
+        "suid": "bin/short-unique-id"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -11348,6 +11358,11 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "short-unique-id": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/short-unique-id/-/short-unique-id-4.4.4.tgz",
+      "integrity": "sha512-oLF1NCmtbiTWl2SqdXZQbo5KM1b7axdp0RgQLq8qCBBLoq+o3A5wmLrNM6bZIh54/a8BJ3l69kTXuxwZ+XCYuw=="
     },
     "side-channel": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "license": "MIT",
   "dependencies": {
     "express": "^4.17.3",
-    "helmet": "^5.0.1"
+    "helmet": "^5.0.1",
+    "short-unique-id": "^4.4.4"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",

--- a/server/app.js
+++ b/server/app.js
@@ -24,9 +24,9 @@ app.post('/api/games', (_req, res) => {
 	res.status(201).json({ game: newGame, status: 201 });
 });
 
-app.get('/api/games/:gameUuid', (req, res, next) => {
-	const playerUuid = req.get('Player-UUID');
-	const game = readGame(req.params.gameUuid, { playerUuid });
+app.get('/api/games/:gameId', (req, res, next) => {
+	const playerId = req.get('Player-ID');
+	const game = readGame(req.params.gameId, { playerId });
 
 	if (game) {
 		return res.status(200).json({ game, status: 200 });
@@ -35,8 +35,8 @@ app.get('/api/games/:gameUuid', (req, res, next) => {
 	next();
 });
 
-app.delete('/api/games/:gameUuid', onlyNonProduction, (req, res, next) => {
-	const isDeleted = removeGame(req.params.gameUuid);
+app.delete('/api/games/:gameId', onlyNonProduction, (req, res, next) => {
+	const isDeleted = removeGame(req.params.gameId);
 
 	if (isDeleted) {
 		return res.sendStatus(204);
@@ -45,10 +45,9 @@ app.delete('/api/games/:gameUuid', onlyNonProduction, (req, res, next) => {
 	next();
 });
 
-app.post('/api/games/:gameUuid/turn', express.json(), (req, res, next) => {
-	console.log({ body: req.body });
-	const { cellToClaim, playerUuid } = req.body;
-	const game = readGame(req.params.gameUuid);
+app.post('/api/games/:gameId/turn', express.json(), (req, res, next) => {
+	const { cellToClaim, playerId } = req.body;
+	const game = readGame(req.params.gameId);
 
 	if (!game) {
 		return next();
@@ -58,9 +57,9 @@ app.post('/api/games/:gameUuid/turn', express.json(), (req, res, next) => {
 		game: updatedGame,
 		isUpdated,
 		message
-	} = updateGame(req.params.gameUuid, {
+	} = updateGame(req.params.gameId, {
 		cellToClaim,
-		playerUuid
+		playerId
 	});
 
 	if (isUpdated) {
@@ -78,9 +77,9 @@ app.post('/api/games/:gameUuid/turn', express.json(), (req, res, next) => {
 
 	logger.warn({
 		event: 'BAD_REQUEST',
-		gameUuid: req.params.gameUuid,
+		gameId: req.params.gameId,
 		cellToClaim,
-		playerUuid,
+		playerId,
 		...body
 	});
 

--- a/server/app.test.js
+++ b/server/app.test.js
@@ -11,6 +11,7 @@ requestWithApiKey.set('API-Key', 'test-key');
 
 const requestWithNoApiKey = supertest.agent(app);
 const requestWithBadApiKey = supertest.agent(app);
+const idRegEx = /[a-zA-Z0-9]{5}/;
 
 requestWithBadApiKey.set('API-Key', 'beep-boop');
 
@@ -47,16 +48,12 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 		});
 
 		it('responds with a 404 for a non-existent game', async () => {
-			const { status } = await requestWithApiKey.get(
-				'/api/games/00000000-0000-0000-0000-000000000000'
-			);
+			const { status } = await requestWithApiKey.get('/api/games/00000');
 			expect(status).toBe(404);
 		});
 
 		it('responds with a 404 when attempting a turn on an non-existent game', async () => {
-			const { status } = await requestWithApiKey.post(
-				'/api/games/00000000-0000-0000-0000-000000000000/turn'
-			);
+			const { status } = await requestWithApiKey.post('/api/games/00000/turn');
 			expect(status).toBe(404);
 		});
 	});
@@ -72,7 +69,7 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 		});
 
 		afterEach(async () => {
-			await requestWithApiKey.delete(`/api/games/${response.body.game.uuid}`);
+			await requestWithApiKey.delete(`/api/games/${response.body.game.id}`);
 		});
 
 		it('responds with a 201 on success', async () => {
@@ -80,36 +77,33 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 		});
 
 		it('responds with a full game model on success', async () => {
-			const uuidRegEx =
-				/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/;
-
 			expect(response.body.game).toEqual({
 				board: {
 					cells: ['', '', '', '', '', '', '', '', ''],
 					winningIndexTrio: null
 				},
 				hasEnded: false,
+				id: expect.stringMatching(idRegEx),
 				players: [
 					{
+						id: expect.stringMatching(idRegEx),
 						isTheirTurn: true,
 						isWinner: null,
-						name: 'Player O',
-						uuid: expect.stringMatching(uuidRegEx)
+						name: 'Player O'
 					},
 					{
+						id: expect.stringMatching(idRegEx),
 						isTheirTurn: false,
 						isWinner: null,
-						name: 'Player X',
-						uuid: expect.stringMatching(uuidRegEx)
+						name: 'Player X'
 					}
-				],
-				uuid: expect.stringMatching(uuidRegEx)
+				]
 			});
 		});
 
-		it('retrieves a game (note the omission of player UUIDs after creation)', async () => {
+		it('retrieves a game (note the omission of player IDs after creation)', async () => {
 			const { body } = await requestWithApiKey.get(
-				`/api/games/${response.body.game.uuid}`
+				`/api/games/${response.body.game.id}`
 			);
 
 			const expectedModel = {
@@ -118,32 +112,32 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 					winningIndexTrio: null
 				},
 				hasEnded: false,
+				id: response.body.game.id,
 				players: [
 					// Player O always starts first
 					{ isTheirTurn: true, isWinner: null, name: 'Player O' },
 					{ isTheirTurn: false, isWinner: null, name: 'Player X' }
-				],
-				uuid: response.body.game.uuid
+				]
 			};
 
 			expect(body.game).toEqual(expectedModel);
 		});
 
-		// This lets API clients validate a player UUID, as well as identify
+		// This lets API clients validate a player ID, as well as identify
 		// when it’s a player’s turn next
-		it('retrieves a game and includes a player UUID if it matches with a header', async () => {
-			const playerUuidX = response.body.game.players[1].uuid;
+		it('retrieves a game and includes a player ID if it matches with a header', async () => {
+			const playerIdX = response.body.game.players[1].id;
 			const { body } = await requestWithApiKey
-				.get(`/api/games/${response.body.game.uuid}`)
-				.set('Player-UUID', playerUuidX);
+				.get(`/api/games/${response.body.game.id}`)
+				.set('Player-ID', playerIdX);
 
 			const expectedPlayers = [
 				{ isTheirTurn: true, isWinner: null, name: 'Player O' },
 				{
+					id: playerIdX,
 					isTheirTurn: false,
 					isWinner: null,
-					name: 'Player X',
-					uuid: playerUuidX
+					name: 'Player X'
 				}
 			];
 
@@ -155,39 +149,39 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 		/**
 		 * @type {string}
 		 */
-		let gameUuid;
+		let gameId;
 		/**
 		 * @type {string}
 		 */
-		let playerUuidX;
+		let playerIdX;
 		/**
 		 * @type {string}
 		 */
-		let playerUuidO;
+		let playerIdO;
 
 		beforeEach(async () => {
 			const { body } = await requestWithApiKey.post('/api/games');
-			gameUuid = body.game.uuid;
-			playerUuidO = body.game.players[0].uuid;
-			playerUuidX = body.game.players[1].uuid;
+			gameId = body.game.id;
+			playerIdO = body.game.players[0].id;
+			playerIdX = body.game.players[1].id;
 		});
 
 		afterEach(async () => {
-			await requestWithApiKey.delete(`/api/games/${gameUuid}`);
+			await requestWithApiKey.delete(`/api/games/${gameId}`);
 		});
 
 		it('allows a valid turn', async () => {
 			const { status } = await requestWithApiKey
-				.post(`/api/games/${gameUuid}/turn`)
-				.send({ cellToClaim: 0, playerUuid: playerUuidO });
+				.post(`/api/games/${gameId}/turn`)
+				.send({ cellToClaim: 0, playerId: playerIdO });
 
 			expect(status).toBe(200);
 		});
 
 		it('serves the updated game in the response body', async () => {
 			const { body } = await requestWithApiKey
-				.post(`/api/games/${gameUuid}/turn`)
-				.send({ cellToClaim: 0, playerUuid: playerUuidO });
+				.post(`/api/games/${gameId}/turn`)
+				.send({ cellToClaim: 0, playerId: playerIdO });
 
 			expect(body.game.board.cells).toEqual([
 				'O',
@@ -204,10 +198,10 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 
 		it('returns the expected change to the game board', async () => {
 			await requestWithApiKey
-				.post(`/api/games/${gameUuid}/turn`)
-				.send({ cellToClaim: 0, playerUuid: playerUuidO });
+				.post(`/api/games/${gameId}/turn`)
+				.send({ cellToClaim: 0, playerId: playerIdO });
 
-			const { body } = await requestWithApiKey.get(`/api/games/${gameUuid}`);
+			const { body } = await requestWithApiKey.get(`/api/games/${gameId}`);
 
 			expect(body.game.board.cells).toEqual([
 				'O',
@@ -226,15 +220,15 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 			// New games always start with player O first, so take their turn
 			// to then make it player X’s turn for this test
 			await requestWithApiKey
-				.post(`/api/games/${gameUuid}/turn`)
-				.send({ cellToClaim: 0, playerUuid: playerUuidO });
+				.post(`/api/games/${gameId}/turn`)
+				.send({ cellToClaim: 0, playerId: playerIdO });
 
 			// Now it’s player X’s turn
 			await requestWithApiKey
-				.post(`/api/games/${gameUuid}/turn`)
-				.send({ cellToClaim: 2, playerUuid: playerUuidX });
+				.post(`/api/games/${gameId}/turn`)
+				.send({ cellToClaim: 2, playerId: playerIdX });
 
-			const { body } = await requestWithApiKey.get(`/api/games/${gameUuid}`);
+			const { body } = await requestWithApiKey.get(`/api/games/${gameId}`);
 
 			expect(body.game.board.cells).toEqual([
 				'O',
@@ -254,25 +248,25 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 		/**
 		 * @type {string}
 		 */
-		let gameUuid;
+		let gameId;
 		/**
 		 * @type {string}
 		 */
-		let playerUuidX;
+		let playerIdX;
 		/**
 		 * @type {string}
 		 */
-		let playerUuidO;
+		let playerIdO;
 
 		beforeEach(async () => {
 			const { body } = await requestWithApiKey.post('/api/games');
-			gameUuid = body.game.uuid;
-			playerUuidO = body.game.players[0].uuid;
-			playerUuidX = body.game.players[1].uuid;
+			gameId = body.game.id;
+			playerIdO = body.game.players[0].id;
+			playerIdX = body.game.players[1].id;
 		});
 
 		afterEach(async () => {
-			await requestWithApiKey.delete(`/api/games/${gameUuid}`);
+			await requestWithApiKey.delete(`/api/games/${gameId}`);
 		});
 
 		// TODO: validate json payload
@@ -280,7 +274,7 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 		describe('with invalid parameters', () => {
 			it('responds with a 400', async () => {
 				const { status } = await requestWithApiKey
-					.post(`/api/games/${gameUuid}/turn`)
+					.post(`/api/games/${gameId}/turn`)
 					.send({ pineapple: 1 });
 
 				expect(status).toBe(400);
@@ -288,7 +282,7 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 
 			it('responds with a message that includes the reason for rejection', async () => {
 				const { body } = await requestWithApiKey
-					.post(`/api/games/${gameUuid}/turn`)
+					.post(`/api/games/${gameId}/turn`)
 					.send({ pineapple: 1 });
 
 				expect(body.message).toEqual(
@@ -300,36 +294,36 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 		describe('when it’s not the player’s turn to take', () => {
 			it('responds with a 400', async () => {
 				await requestWithApiKey
-					.post(`/api/games/${gameUuid}/turn`)
-					.send({ cellToClaim: 0, playerUuid: playerUuidO });
+					.post(`/api/games/${gameId}/turn`)
+					.send({ cellToClaim: 0, playerId: playerIdO });
 
 				const { status } = await requestWithApiKey
-					.post(`/api/games/${gameUuid}/turn`)
-					.send({ cellToClaim: 1, playerUuid: playerUuidO });
+					.post(`/api/games/${gameId}/turn`)
+					.send({ cellToClaim: 1, playerId: playerIdO });
 
 				expect(status).toBe(400);
 			});
 
 			it('responds with a message that includes the reason for rejection', async () => {
 				await requestWithApiKey
-					.post(`/api/games/${gameUuid}/turn`)
-					.send({ cellToClaim: 0, playerUuid: playerUuidO });
+					.post(`/api/games/${gameId}/turn`)
+					.send({ cellToClaim: 0, playerId: playerIdO });
 
 				const { body } = await requestWithApiKey
-					.post(`/api/games/${gameUuid}/turn`)
-					.send({ cellToClaim: 1, playerUuid: playerUuidO });
+					.post(`/api/games/${gameId}/turn`)
+					.send({ cellToClaim: 1, playerId: playerIdO });
 
 				expect(body.message).toBe('It is not this player’s turn');
 			});
 		});
 
-		describe('when the given player UUID is invalid', () => {
+		describe('when the given player ID is invalid', () => {
 			it('responds with a 400', async () => {
 				const { status } = await requestWithApiKey
-					.post(`/api/games/${gameUuid}/turn`)
+					.post(`/api/games/${gameId}/turn`)
 					.send({
 						cellToClaim: 0,
-						playerUuid: '00000000-0000-0000-0000-000000000000'
+						playerId: '00000'
 					});
 
 				expect(status).toBe(400);
@@ -337,10 +331,10 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 
 			it('responds with a message that includes the reason for rejection', async () => {
 				const { body } = await requestWithApiKey
-					.post(`/api/games/${gameUuid}/turn`)
+					.post(`/api/games/${gameId}/turn`)
 					.send({
 						cellToClaim: 0,
-						playerUuid: '00000000-0000-0000-0000-000000000000'
+						playerId: '00000'
 					});
 
 				expect(body.message).toBe('Player not found');
@@ -350,10 +344,10 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 		describe('when an attempt is made to claim an invalid cell', () => {
 			it('responds with a 400', async () => {
 				const { status } = await requestWithApiKey
-					.post(`/api/games/${gameUuid}/turn`)
+					.post(`/api/games/${gameId}/turn`)
 					.send({
 						cellToClaim: 42,
-						playerUuid: playerUuidO
+						playerId: playerIdO
 					});
 
 				expect(status).toBe(400);
@@ -361,10 +355,10 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 
 			it('responds with a message that includes the reason for rejection', async () => {
 				const { body } = await requestWithApiKey
-					.post(`/api/games/${gameUuid}/turn`)
+					.post(`/api/games/${gameId}/turn`)
 					.send({
 						cellToClaim: 42,
-						playerUuid: playerUuidO
+						playerId: playerIdO
 					});
 
 				expect(body.message).toBe(
@@ -375,32 +369,32 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 
 		describe('when an attempt is made to claim an already-claimed cell', () => {
 			it('responds with a 400', async () => {
-				await requestWithApiKey.post(`/api/games/${gameUuid}/turn`).send({
+				await requestWithApiKey.post(`/api/games/${gameId}/turn`).send({
 					cellToClaim: 0,
-					playerUuid: playerUuidO
+					playerId: playerIdO
 				});
 
 				const { status } = await requestWithApiKey
-					.post(`/api/games/${gameUuid}/turn`)
+					.post(`/api/games/${gameId}/turn`)
 					.send({
 						cellToClaim: 0,
-						playerUuid: playerUuidX
+						playerId: playerIdX
 					});
 
 				expect(status).toBe(400);
 			});
 
 			it('responds with a message that includes the reason for rejection', async () => {
-				await requestWithApiKey.post(`/api/games/${gameUuid}/turn`).send({
+				await requestWithApiKey.post(`/api/games/${gameId}/turn`).send({
 					cellToClaim: 0,
-					playerUuid: playerUuidO
+					playerId: playerIdO
 				});
 
 				const { body } = await requestWithApiKey
-					.post(`/api/games/${gameUuid}/turn`)
+					.post(`/api/games/${gameId}/turn`)
 					.send({
 						cellToClaim: 0,
-						playerUuid: playerUuidX
+						playerId: playerIdX
 					});
 
 				expect(body.message).toBe('This cell has already been claimed');
@@ -417,17 +411,17 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 					['O', 2]
 				]) {
 					const [player, cellToClaim] = turn;
-					await requestWithApiKey.post(`/api/games/${gameUuid}/turn`).send({
+					await requestWithApiKey.post(`/api/games/${gameId}/turn`).send({
 						cellToClaim,
-						playerUuid: player === 'O' ? playerUuidO : playerUuidX
+						playerId: player === 'O' ? playerIdO : playerIdX
 					});
 				}
 
 				const { status } = await requestWithApiKey
-					.post(`/api/games/${gameUuid}/turn`)
+					.post(`/api/games/${gameId}/turn`)
 					.send({
 						cellToClaim: 5,
-						playerUuid: playerUuidX
+						playerId: playerIdX
 					});
 
 				expect(status).toBe(400);
@@ -442,17 +436,17 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 					['O', 2]
 				]) {
 					const [player, cellToClaim] = turn;
-					await requestWithApiKey.post(`/api/games/${gameUuid}/turn`).send({
+					await requestWithApiKey.post(`/api/games/${gameId}/turn`).send({
 						cellToClaim,
-						playerUuid: player === 'O' ? playerUuidO : playerUuidX
+						playerId: player === 'O' ? playerIdO : playerIdX
 					});
 				}
 
 				const { body } = await requestWithApiKey
-					.post(`/api/games/${gameUuid}/turn`)
+					.post(`/api/games/${gameId}/turn`)
 					.send({
 						cellToClaim: 5,
-						playerUuid: playerUuidX
+						playerId: playerIdX
 					});
 
 				expect(body.message).toBe('This game has already ended');
@@ -469,17 +463,17 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 					['O', 7]
 				]) {
 					const [player, cellToClaim] = turn;
-					await requestWithApiKey.post(`/api/games/${gameUuid}/turn`).send({
+					await requestWithApiKey.post(`/api/games/${gameId}/turn`).send({
 						cellToClaim,
-						playerUuid: player === 'O' ? playerUuidO : playerUuidX
+						playerId: player === 'O' ? playerIdO : playerIdX
 					});
 				}
 
 				const { status } = await requestWithApiKey
-					.post(`/api/games/${gameUuid}/turn`)
+					.post(`/api/games/${gameId}/turn`)
 					.send({
 						cellToClaim: 6,
-						playerUuid: playerUuidX
+						playerId: playerIdX
 					});
 
 				expect(status).toBe(400);
@@ -494,17 +488,17 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 					['O', 7]
 				]) {
 					const [player, cellToClaim] = turn;
-					await requestWithApiKey.post(`/api/games/${gameUuid}/turn`).send({
+					await requestWithApiKey.post(`/api/games/${gameId}/turn`).send({
 						cellToClaim,
-						playerUuid: player === 'O' ? playerUuidO : playerUuidX
+						playerId: player === 'O' ? playerIdO : playerIdX
 					});
 				}
 
 				const { body } = await requestWithApiKey
-					.post(`/api/games/${gameUuid}/turn`)
+					.post(`/api/games/${gameId}/turn`)
 					.send({
 						cellToClaim: 6,
-						playerUuid: playerUuidX
+						playerId: playerIdX
 					});
 
 				expect(body.message).toBe('This game has already ended');
@@ -521,17 +515,17 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 					['O', 6]
 				]) {
 					const [player, cellToClaim] = turn;
-					await requestWithApiKey.post(`/api/games/${gameUuid}/turn`).send({
+					await requestWithApiKey.post(`/api/games/${gameId}/turn`).send({
 						cellToClaim,
-						playerUuid: player === 'O' ? playerUuidO : playerUuidX
+						playerId: player === 'O' ? playerIdO : playerIdX
 					});
 				}
 
 				const { status } = await requestWithApiKey
-					.post(`/api/games/${gameUuid}/turn`)
+					.post(`/api/games/${gameId}/turn`)
 					.send({
 						cellToClaim: 8,
-						playerUuid: playerUuidX
+						playerId: playerIdX
 					});
 
 				expect(status).toBe(400);
@@ -546,17 +540,17 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 					['O', 6]
 				]) {
 					const [player, cellToClaim] = turn;
-					await requestWithApiKey.post(`/api/games/${gameUuid}/turn`).send({
+					await requestWithApiKey.post(`/api/games/${gameId}/turn`).send({
 						cellToClaim,
-						playerUuid: player === 'O' ? playerUuidO : playerUuidX
+						playerId: player === 'O' ? playerIdO : playerIdX
 					});
 				}
 
 				const { body } = await requestWithApiKey
-					.post(`/api/games/${gameUuid}/turn`)
+					.post(`/api/games/${gameId}/turn`)
 					.send({
 						cellToClaim: 8,
-						playerUuid: playerUuidX
+						playerId: playerIdX
 					});
 
 				expect(body.message).toBe('This game has already ended');
@@ -567,17 +561,17 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 			it('responds with a 400', async () => {
 				// Simulate a full game being played
 				for (let index = 0; index < 9; index += 1) {
-					await requestWithApiKey.post(`/api/games/${gameUuid}/turn`).send({
+					await requestWithApiKey.post(`/api/games/${gameId}/turn`).send({
 						cellToClaim: index,
-						playerUuid: index % 2 === 0 ? playerUuidO : playerUuidX
+						playerId: index % 2 === 0 ? playerIdO : playerIdX
 					});
 				}
 
 				const { status } = await requestWithApiKey
-					.post(`/api/games/${gameUuid}/turn`)
+					.post(`/api/games/${gameId}/turn`)
 					.send({
 						cellToClaim: 0,
-						playerUuid: playerUuidX
+						playerId: playerIdX
 					});
 
 				expect(status).toBe(400);
@@ -586,17 +580,17 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 			it('responds with a message that includes the reason for rejection', async () => {
 				// Simulate a full game being played
 				for (let index = 0; index < 9; index += 1) {
-					await requestWithApiKey.post(`/api/games/${gameUuid}/turn`).send({
+					await requestWithApiKey.post(`/api/games/${gameId}/turn`).send({
 						cellToClaim: index,
-						playerUuid: index % 2 === 0 ? playerUuidO : playerUuidX
+						playerId: index % 2 === 0 ? playerIdO : playerIdX
 					});
 				}
 
 				const { body } = await requestWithApiKey
-					.post(`/api/games/${gameUuid}/turn`)
+					.post(`/api/games/${gameId}/turn`)
 					.send({
 						cellToClaim: 0,
-						playerUuid: playerUuidX
+						playerId: playerIdX
 					});
 
 				expect(body.message).toBe(
@@ -610,25 +604,25 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 		/**
 		 * @type {string}
 		 */
-		let gameUuid;
+		let gameId;
 		/**
 		 * @type {string}
 		 */
-		let playerUuidX;
+		let playerIdX;
 		/**
 		 * @type {string}
 		 */
-		let playerUuidO;
+		let playerIdO;
 
 		beforeEach(async () => {
 			const { body } = await requestWithApiKey.post('/api/games');
-			gameUuid = body.game.uuid;
-			playerUuidO = body.game.players[0].uuid;
-			playerUuidX = body.game.players[1].uuid;
+			gameId = body.game.id;
+			playerIdO = body.game.players[0].id;
+			playerIdX = body.game.players[1].id;
 		});
 
 		afterEach(async () => {
-			await requestWithApiKey.delete(`/api/games/${gameUuid}`);
+			await requestWithApiKey.delete(`/api/games/${gameId}`);
 		});
 
 		it('includes an array of the winning cell indexes after a win', async () => {
@@ -640,13 +634,13 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 				['O', 2]
 			]) {
 				const [player, cellToClaim] = turn;
-				await requestWithApiKey.post(`/api/games/${gameUuid}/turn`).send({
+				await requestWithApiKey.post(`/api/games/${gameId}/turn`).send({
 					cellToClaim,
-					playerUuid: player === 'O' ? playerUuidO : playerUuidX
+					playerId: player === 'O' ? playerIdO : playerIdX
 				});
 			}
 
-			const { body } = await requestWithApiKey.get(`/api/games/${gameUuid}`);
+			const { body } = await requestWithApiKey.get(`/api/games/${gameId}`);
 
 			expect(body.game.board).toEqual({
 				cells: ['O', 'O', 'O', 'X', 'X', '', '', '', ''],
@@ -663,13 +657,13 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 				['O', 2]
 			]) {
 				const [player, cellToClaim] = turn;
-				await requestWithApiKey.post(`/api/games/${gameUuid}/turn`).send({
+				await requestWithApiKey.post(`/api/games/${gameId}/turn`).send({
 					cellToClaim,
-					playerUuid: player === 'O' ? playerUuidO : playerUuidX
+					playerId: player === 'O' ? playerIdO : playerIdX
 				});
 			}
 
-			const { body } = await requestWithApiKey.get(`/api/games/${gameUuid}`);
+			const { body } = await requestWithApiKey.get(`/api/games/${gameId}`);
 
 			expect(body.game.players[0].isWinner).toBe(true);
 		});
@@ -680,16 +674,16 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 		/**
 		 * @type {string}
 		 */
-		let gameUuid;
+		let gameId;
 
 		beforeEach(async () => {
 			const { body } = await requestWithApiKey.post('/api/games');
-			gameUuid = body.game.uuid;
+			gameId = body.game.id;
 		});
 
 		afterEach(async () => {
 			config.IS_PRODUCTION = false;
-			await requestWithApiKey.delete(`/api/games/${gameUuid}`);
+			await requestWithApiKey.delete(`/api/games/${gameId}`);
 			config.IS_PRODUCTION = originalIsProduction;
 		});
 
@@ -698,9 +692,7 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 		it('serves a delete route if not in production', async () => {
 			config.IS_PRODUCTION = false;
 
-			const { status } = await requestWithApiKey.delete(
-				`/api/games/${gameUuid}`
-			);
+			const { status } = await requestWithApiKey.delete(`/api/games/${gameId}`);
 
 			expect(status).toEqual(204);
 		});
@@ -708,8 +700,8 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 		it('deletes a game if not in production', async () => {
 			config.IS_PRODUCTION = false;
 
-			await requestWithApiKey.delete(`/api/games/${gameUuid}`);
-			const { status } = await requestWithApiKey.get(`/api/games/${gameUuid}`);
+			await requestWithApiKey.delete(`/api/games/${gameId}`);
+			const { status } = await requestWithApiKey.get(`/api/games/${gameId}`);
 
 			expect(status).toEqual(404);
 		});
@@ -717,9 +709,7 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 		it('doesn’t serve a delete route if in production', async () => {
 			config.IS_PRODUCTION = true;
 
-			const { status } = await requestWithApiKey.delete(
-				`/api/games/${gameUuid}`
-			);
+			const { status } = await requestWithApiKey.delete(`/api/games/${gameId}`);
 
 			expect(status).toEqual(405);
 		});
@@ -727,9 +717,9 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 		it('doesn’t delete a game if in production', async () => {
 			config.IS_PRODUCTION = true;
 
-			await requestWithApiKey.delete(`/api/games/${gameUuid}`);
+			await requestWithApiKey.delete(`/api/games/${gameId}`);
 
-			const { status } = await requestWithApiKey.get(`/api/games/${gameUuid}`);
+			const { status } = await requestWithApiKey.get(`/api/games/${gameId}`);
 
 			expect(status).toEqual(200);
 		});


### PR DESCRIPTION
## Problem

Game and player IDs make a full turn URL really long and
unreadable. These URLs are meant to be easy to share between players so it seems important to keep them short.

## Solution

We don’t really need 36 character UUIDs for game and player IDs because
we’re prettty unlikely to ever have an ID clash with like, at most, 20 or so active
games at a time! These games are meant to be short-lived, so it should be
fine to shorten the IDs. This commit changes them to be alphnumeric 5
character strings.

**BREAKING CHANGE:** Any mention of `uuid` or `playerUuid` in API responses will
now be `id` and `playerId`, respectively. ID lengths are also now 5
alphanumeric characters instead of the 36 character hex (plus dash)
format of v4 UUIDs. This kind of change is unlikely to happen again,
unless this API becomes inexplicably popular for some strange reason.