### PR TITLE
✨ feature: enable two players to play subsequent games with one another

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,18 +56,21 @@ No request body is required or supported. The response body will be in JSON form
 		"winningIndexTrio": null
 	},
 	"hasEnded": false,
+	"id": "00000",
+	"nextId": null,
 	"players": [{
 		"isTheirTurn": true,
 		"isWinner": null,
 		"name": "Player O",
+		"nextId": null
 		"id": "11111"
 	}, {
 		"isTheirTurn": false,
 		"isWinner": null,
 		"name": "Player X",
+		"nextId": null
 		"id": "22222"
 	}],
-	"id": "00000"
 }
 ```
 
@@ -96,16 +99,19 @@ which of the players in the players array is actually them. In other words, send
 		"winningIndexTrio": null
 	},
 	"hasEnded": false,
+	"id": "00000",
+	"nextId": null,
 	"players": [{
 		"isTheirTurn": true,
 		"isWinner": null,
-		"name": "Player O"
+		"name": "Player O",
+		"nextId": null,
 	}, {
 		"isTheirTurn": false,
 		"isWinner": null,
-		"name": "Player X"
+		"name": "Player X",
+		"nextId": null
 	}],
-	"id": "00000"
 }
 ```
 
@@ -120,23 +126,30 @@ which of the players in the players array is actually them. In other words, send
 		"winningIndexTrio": null
 	},
 	"hasEnded": false,
+	"id": "00000",
+	"nextId": null,
 	"players": [{
 		"isTheirTurn": true,
 		"isWinner": null,
-		"name": "Player O"
+		"name": "Player O",
+		"nextId": null
 	}, {
+		"id": "22222",
 		"isTheirTurn": false,
 		"isWinner": null,
 		"name": "Player X",
-		"id": "22222"
+		"nextId": null
 	}],
-	"id": "00000"
 }
 ```
 
 ### `POST /api/games/:gameId/turn`
 
-Calls to `/api/games/:gameId/turn` will change the state of the game board by taking the requested player’s turn in the game. Requests must include a `Content-Type` header with a value of `application/json`. If a successful response is returned, it will then be the other player’s turn.
+Calls to `/api/games/:gameId/turn` will change the state of the game board by taking the requested player’s turn in the game. Requests must include a `Content-Type` header with a value of `application/json`. If a successful response is returned, it will then be the other player’s turn unless you win, or there are no more spaces left on the board.
+
+:information_source: When a game ends, a new game is created automatically and its data is shared in
+any subsequent responses, with the same mechanism in place that omits player IDs unless you specify one with a `Player-ID` header in the request. This approach of perpetually creating subsequent games makes it possible for two players to continue playing each other across multiple games,
+without having to share new URLs between each other.
 
 #### Example request
 
@@ -163,16 +176,19 @@ Calls to `/api/games/:gameId/turn` will change the state of the game board by ta
 		"winningIndexTrio": null
 	},
 	"hasEnded": false,
+	"id": "00000",
+	"nextId": null,
 	"players": [{
 		"isTheirTurn": false,
 		"isWinner": null,
-		"name": "Player O"
+		"name": "Player O",
+		"nextId": null
 	}, {
 		"isTheirTurn": true,
 		"isWinner": null,
 		"name": "Player X"
-	}],
-	"id": "00000"
+		"nextId": null
+	}]
 }
 ```
 

--- a/server/game.js
+++ b/server/game.js
@@ -39,11 +39,15 @@ const toPublicGame = (game, { omitPlayerIds = true, playerId } = {}) => {
 
 	if (omitPlayerIds && !playerId) {
 		delete playerO.id;
+		delete playerO.nextId;
 		delete playerX.id;
+		delete playerX.nextId;
 	} else if (omitPlayerIds && playerId === playerO.id) {
 		delete playerX.id;
+		delete playerX.nextId;
 	} else if (omitPlayerIds && playerId === playerX.id) {
 		delete playerO.id;
+		delete playerO.nextId;
 	}
 
 	return publicGame;
@@ -72,18 +76,21 @@ export const create = () => {
 			winningIndexTrio: null
 		},
 		hasEnded: false,
+		nextId: null,
 		players: [
 			{
 				id: createId(),
 				isTheirTurn: true,
 				isWinner: null,
-				name: 'Player O'
+				name: 'Player O',
+				nextId: null
 			},
 			{
 				id: createId(),
 				isTheirTurn: false,
 				isWinner: null,
-				name: 'Player X'
+				name: 'Player X',
+				nextId: null
 			}
 		],
 		id: createId()
@@ -168,6 +175,11 @@ export const update = (idToUpdate, { cellToClaim, playerId }) => {
 
 	if (hasEndedNow) {
 		game.hasEnded = hasEndedNow;
+		const nextGame = create();
+
+		game.nextId = nextGame.id;
+		game.players[0].nextId = nextGame.players[0].id;
+		game.players[1].nextId = nextGame.players[1].id;
 	}
 
 	if (player && winningIndexTrio?.length) {
@@ -249,6 +261,7 @@ const judgeBoard = (board) => {
  * @property {boolean} isTheirTurn
  * @property {boolean | null} isWinner
  * @property {string} name
+ * @property {id | null} nextId
  * @property {id} id
  *
  * @typedef {playerModel[]} playersModel
@@ -256,6 +269,7 @@ const judgeBoard = (board) => {
  * @typedef gameModel
  * @property {boardModel} board
  * @property {boolean} hasEnded
+ * @property {id | null} nextId
  * @property {id} id
  * @property {playersModel} players
  *


### PR DESCRIPTION
When a game ends, a new game is created automatically and its data is shared in
any subsequent responses, with the same mechanism in place that omits player IDs
unless you specify one with a `Player-ID` header in the request. This approach
of perpetually creating subsequent games makes it possible for two players to
continue playing each other across multiple games, without having to share new
URLs between each other.