### PR TITLE
refactor: rename a property in the player model for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ No request body is required or supported. The response body will be in JSON form
 	"id": "00000",
 	"nextId": null,
 	"players": [{
-		"isTheirTurn": true,
+		"isTurn": true,
 		"isWinner": null,
 		"name": "Player O",
 		"nextId": null,
 		"id": "11111"
 	}, {
-		"isTheirTurn": false,
+		"isTurn": false,
 		"isWinner": null,
 		"name": "Player X",
 		"nextId": null,
@@ -102,12 +102,12 @@ which of the players in the players array is actually them. In other words, send
 	"id": "00000",
 	"nextId": null,
 	"players": [{
-		"isTheirTurn": true,
+		"isTurn": true,
 		"isWinner": null,
 		"name": "Player O",
 		"nextId": null,
 	}, {
-		"isTheirTurn": false,
+		"isTurn": false,
 		"isWinner": null,
 		"name": "Player X",
 		"nextId": null
@@ -129,13 +129,13 @@ which of the players in the players array is actually them. In other words, send
 	"id": "00000",
 	"nextId": null,
 	"players": [{
-		"isTheirTurn": true,
+		"isTurn": true,
 		"isWinner": null,
 		"name": "Player O",
 		"nextId": null
 	}, {
 		"id": "22222",
-		"isTheirTurn": false,
+		"isTurn": false,
 		"isWinner": null,
 		"name": "Player X",
 		"nextId": null
@@ -179,12 +179,12 @@ without having to share new URLs between each other.
 	"id": "00000",
 	"nextId": null,
 	"players": [{
-		"isTheirTurn": false,
+		"isTurn": false,
 		"isWinner": null,
 		"name": "Player O",
 		"nextId": null
 	}, {
-		"isTheirTurn": true,
+		"isTurn": true,
 		"isWinner": null,
 		"name": "Player X"
 		"nextId": null

--- a/server/app.test.js
+++ b/server/app.test.js
@@ -88,14 +88,14 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 				players: [
 					{
 						id: expect.stringMatching(idRegEx),
-						isTheirTurn: true,
+						isTurn: true,
 						isWinner: null,
 						name: 'Player O',
 						nextId: null
 					},
 					{
 						id: expect.stringMatching(idRegEx),
-						isTheirTurn: false,
+						isTurn: false,
 						isWinner: null,
 						name: 'Player X',
 						nextId: null
@@ -119,8 +119,8 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 				nextId: null,
 				players: [
 					// Player O always starts first
-					{ isTheirTurn: true, isWinner: null, name: 'Player O' },
-					{ isTheirTurn: false, isWinner: null, name: 'Player X' }
+					{ isTurn: true, isWinner: null, name: 'Player O' },
+					{ isTurn: false, isWinner: null, name: 'Player X' }
 				]
 			};
 
@@ -136,10 +136,10 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 				.set('Player-ID', playerIdX);
 
 			const expectedPlayers = [
-				{ isTheirTurn: true, isWinner: null, name: 'Player O' },
+				{ isTurn: true, isWinner: null, name: 'Player O' },
 				{
 					id: playerIdX,
-					isTheirTurn: false,
+					isTurn: false,
 					isWinner: null,
 					name: 'Player X',
 					nextId: null
@@ -694,13 +694,13 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 				players: [
 					{
 						id: nextPlayerId,
-						isTheirTurn: true,
+						isTurn: true,
 						isWinner: null,
 						name: 'Player O',
 						nextId: null
 					},
 					{
-						isTheirTurn: false,
+						isTurn: false,
 						isWinner: null,
 						name: 'Player X'
 					}
@@ -730,13 +730,13 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 				nextId: null,
 				players: [
 					{
-						isTheirTurn: true,
+						isTurn: true,
 						isWinner: null,
 						name: 'Player O'
 					},
 					{
 						id: nextPlayerId,
-						isTheirTurn: false,
+						isTurn: false,
 						isWinner: null,
 						name: 'Player X',
 						nextId: null

--- a/server/game.js
+++ b/server/game.js
@@ -80,14 +80,14 @@ export const create = () => {
 		players: [
 			{
 				id: createId(),
-				isTheirTurn: true,
+				isTurn: true,
 				isWinner: null,
 				name: 'Player O',
 				nextId: null
 			},
 			{
 				id: createId(),
-				isTheirTurn: false,
+				isTurn: false,
 				isWinner: null,
 				name: 'Player X',
 				nextId: null
@@ -153,7 +153,7 @@ export const update = (idToUpdate, { cellToClaim, playerId }) => {
 
 	if (!player) {
 		errorMessages.push('Player not found');
-	} else if (!player.isTheirTurn) {
+	} else if (!player.isTurn) {
 		errorMessages.push('It is not this player’s turn');
 	}
 
@@ -168,8 +168,8 @@ export const update = (idToUpdate, { cellToClaim, playerId }) => {
 	}
 
 	board.cells.set(cellToClaim, playerId === players[0].id ? 'O' : 'X');
-	players[0].isTheirTurn = !players[0].isTheirTurn;
-	players[1].isTheirTurn = !players[1].isTheirTurn;
+	players[0].isTurn = !players[0].isTurn;
+	players[1].isTurn = !players[1].isTurn;
 
 	const { hasEnded: hasEndedNow, winningIndexTrio } = judgeBoard(game.board);
 
@@ -258,7 +258,7 @@ const judgeBoard = (board) => {
  * @property {cellNumber[] | null} winningIndexTrio
  *
  * @typedef playerModel
- * @property {boolean} isTheirTurn
+ * @property {boolean} isTurn
  * @property {boolean | null} isWinner
  * @property {string} name
  * @property {id | null} nextId


### PR DESCRIPTION
Having a player property called `isTheirTurn`, in hindsight, wasn’t a great choice: using the singular third-person for a player makes it unclear whether a property refers to that player or their opponent. For example, if `player.isTheirTurn` is `true`, does that mean it’s that player’s turn, or is it their opponent’s turn? By renaming the property to `isTurn`, the problem is avoided.

BREAKING CHANGE: Any references to `isTheirTurn` will need to be changed to `isTurn`.