### PR TITLE
🛠 refactor: change mechanism for including player id in response

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ both players’ IDs!
 ### `GET /api/games/:gameId`
 
 Send a GET request to `/api/games/:gameId` to receive the current state of your Tic-tac-toe game.
-Accepts an optional header, `Player-ID`, if you want to include the ID of a player in the
+Accepts an optional query parameter, `playerId`, if you want to include the ID of a player in the
 response. This header is useful for inferring the state of a player, for example: if you want to
 serve an HTML page to the player, in order to infer if it’s their turn in the game, you need to know
-which of the players in the players array is actually them. In other words, sending the `Player-ID` header lets you identify a player within the response’s players array.
+which of the players in the players array is actually them. In other words, sending the `playerId=abc` query parameter lets you identify a player within the response’s players array.
 
-#### Example response of a request with no optional `Player-ID` header
+#### Example response of a request with no optional `playerId` query parameter
 
 `200 OK`
 
@@ -115,7 +115,7 @@ which of the players in the players array is actually them. In other words, send
 }
 ```
 
-#### Example response of a request with a `Player-ID` header of `22222`
+#### Example response of a request with a `playerId` query parameter of `22222`
 
 `200 OK`
 
@@ -148,7 +148,7 @@ which of the players in the players array is actually them. In other words, send
 Calls to `/api/games/:gameId/turn` will change the state of the game board by taking the requested player’s turn in the game. Requests must include a `Content-Type` header with a value of `application/json`. If a successful response is returned, it will then be the other player’s turn unless you win, or there are no more spaces left on the board.
 
 :information_source: When a game ends, a new game is created automatically and its IDs are shared in
-any subsequent responses via a `nextId` property, with the same mechanism in place that omits player IDs unless you specify one with a `Player-ID` header in the request. This approach of perpetually creating subsequent games makes it possible for two players to continue playing each other across multiple games,
+any subsequent responses via a `nextId` property, with the same mechanism in place that omits player IDs unless you specify one with a `playerId` query parameter in the request. This approach of perpetually creating subsequent games makes it possible for two players to continue playing each other across multiple games,
 without having to share new URLs between each other.
 
 #### Example request

--- a/server/app.js
+++ b/server/app.js
@@ -25,8 +25,14 @@ app.post('/api/games', (_req, res) => {
 });
 
 app.get('/api/games/:gameId', (req, res, next) => {
-	const playerId = req.get('Player-ID');
-	const game = readGame(req.params.gameId, { playerId });
+	const { playerId } = req.query;
+	const options = {};
+
+	if (typeof playerId === 'string') {
+		options.playerId = playerId;
+	}
+
+	const game = readGame(req.params.gameId, options);
 
 	if (game) {
 		return res.status(200).json({ game, status: 200 });

--- a/server/app.test.js
+++ b/server/app.test.js
@@ -129,11 +129,11 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 
 		// This lets API clients validate a player ID, as well as identify
 		// when it’s a player’s turn next
-		it('retrieves a game and includes a player ID if it matches with a header', async () => {
+		it('retrieves a game and includes a player ID if it matches with a given query parameter', async () => {
 			const playerIdX = response.body.game.players[1].id;
-			const { body } = await requestWithApiKey
-				.get(`/api/games/${response.body.game.id}`)
-				.set('Player-ID', playerIdX);
+			const { body } = await requestWithApiKey.get(
+				`/api/games/${response.body.game.id}?playerId=${playerIdX}`
+			);
 
 			const expectedPlayers = [
 				{ isTurn: true, isWinner: null, name: 'Player O' },
@@ -674,15 +674,15 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 		it('produces a new game and shares a player-specific URL for player O', async () => {
 			await playGameStartToFinish({ gameId, playerIdO, playerIdX });
 
-			const { body } = await requestWithApiKey
-				.get(`/api/games/${gameId}`)
-				.set('Player-ID', playerIdO);
+			const { body } = await requestWithApiKey.get(
+				`/api/games/${gameId}?playerId=${playerIdO}`
+			);
 
 			const nextGameId = body.game.nextId;
 			const nextPlayerId = body.game.players[0].nextId;
-			const { body: newBody } = await requestWithApiKey
-				.get(`/api/games/${nextGameId}`)
-				.set('Player-ID', nextPlayerId);
+			const { body: newBody } = await requestWithApiKey.get(
+				`/api/games/${nextGameId}?playerId=${nextPlayerId}`
+			);
 
 			expect(newBody.game).toEqual({
 				board: {
@@ -712,14 +712,14 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 		it('produces a new game and shares a player-specific URL for player X', async () => {
 			await playGameStartToFinish({ gameId, playerIdO, playerIdX });
 
-			const { body } = await requestWithApiKey
-				.get(`/api/games/${gameId}`)
-				.set('Player-ID', playerIdX);
+			const { body } = await requestWithApiKey.get(
+				`/api/games/${gameId}?playerId=${playerIdX}`
+			);
 			const nextGameId = body.game.nextId;
 			const nextPlayerId = body.game.players[1].nextId;
-			const { body: newBody } = await requestWithApiKey
-				.get(`/api/games/${nextGameId}`)
-				.set('Player-ID', nextPlayerId);
+			const { body: newBody } = await requestWithApiKey.get(
+				`/api/games/${nextGameId}?playerId=${nextPlayerId}`
+			);
 
 			expect(newBody.game).toEqual({
 				board: {


### PR DESCRIPTION
I’m playing around with a low-cost CDN (bunny.net) that I’m using for reverse-proxying and caching of this game. That’s quite fun but it turns out, the CDN doesn’t support varying the cache on a custom header (in this case, 'Player-ID'), so I’d have some cache clashing issues soon when I start introducing more caching to the game. Rabbit does support varying on query string values though, so this commit is the workaround.

BREAKING CHANGE: For anyone(?) relying on the `Player-ID` header to trigger the inclusion of playerIds in responses: You’ll need to change requests to include a query parameter `playerId`, in replacement of the `Player-ID` header. The query param value should be the same as old header’s value.